### PR TITLE
taking the last value as time parameter so that user can pass there own

### DIFF
--- a/lib/command/commands/recursive.js
+++ b/lib/command/commands/recursive.js
@@ -29,7 +29,7 @@ externals.Recursive = class extends Command {
   preprocess (parsedMessage) {
     return Promise.resolve({
       then: (onFulfill, onReject) => {
-        let time = this.getParams(parsedMessage, 0);
+        let time = this.getParams(parsedMessage, _.get(parsedMessage, 'message.params', []).length-1);
         time = _.isNumber(time) ? time : 1;
 
         if (this.getCommand().timeUnit === 'h') {


### PR DESCRIPTION
param list along with time preferences. 
Currently if the user wishes to use a parameter with the schedule command alongwith passing a time parameter, the time parameter is ignored in that case. Hence instead of heardcoding to look at the 0th index for time parameter, i am changing it to look at the last one, so that the user can stuff his own params in the middle.
For eg: 
Previously: SLACK-COMMAND <PARAM LIST> <IGNORED-TIME-PARAM>
After Change: SLACK-COMMAND <PARAM LIST> <TIME-PARAM>
